### PR TITLE
Visualization of alphagenome's codebase

### DIFF
--- a/.codeboarding/Genomic_Data_Management.md
+++ b/.codeboarding/Genomic_Data_Management.md
@@ -1,0 +1,175 @@
+```mermaid
+
+graph LR
+
+    Genomic_Intervals_Junctions["Genomic Intervals & Junctions"]
+
+    Quantitative_Genomic_Tracks["Quantitative Genomic Tracks"]
+
+    Biological_Ontology_Terms["Biological Ontology Terms"]
+
+    Transcript_Annotations["Transcript Annotations"]
+
+    Gene_Annotations["Gene Annotations"]
+
+    Junction_Data_Structures["Junction Data Structures"]
+
+    Interval_Folding_Utilities["Interval Folding Utilities"]
+
+    Genomic_Data_Management -- "provides data structures to" --> API_Client_Service_Layer
+
+    Genomic_Data_Management -- "provides data structures to" --> Interpretation_Layer
+
+    Genomic_Data_Management -- "provides data structures to" --> Visualization_Layer
+
+    Genomic_Data_Management -- "depends on" --> Protocol_Definition_Layer
+
+    Genomic_Data_Management -- "depends on" --> Utility_Layer
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This foundational component, `Genomic Data Management`, is responsible for defining, managing, and providing core genomic data structures within the `alphagenome` SDK. It acts as the primary data layer, ensuring consistent representation and manipulation of genomic entities across the entire system. Its design emphasizes modularity, with each sub-component focusing on a specific type of genomic data or annotation. This component is fundamental because it provides the essential building blocks for all downstream analyses, model interactions, and visualizations, ensuring data integrity and facilitating interoperability within the SDK.
+
+
+
+### Genomic Intervals & Junctions
+
+Defines fundamental genomic coordinates and structures, including `Interval` (representing a contiguous genomic region) and `Junction` (representing a connection between two genomic intervals, often used for splice junctions). It provides the basic building blocks for all other genomic data types.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/genome.py#L1-L1" target="_blank" rel="noopener noreferrer">`alphagenome.data.genome` (1:1)</a>
+
+
+
+
+
+### Quantitative Genomic Tracks
+
+Manages quantitative genomic data, such as read coverage, signal intensity, or conservation scores, typically represented as numerical values across genomic intervals. It provides structures for storing and accessing this data efficiently.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/track_data.py#L1-L1" target="_blank" rel="noopener noreferrer">`alphagenome.data.track_data` (1:1)</a>
+
+
+
+
+
+### Biological Ontology Terms
+
+Defines and manages biological ontology terms, such as Gene Ontology (GO) terms or disease terms, allowing for the structured representation and categorization of biological concepts.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/ontology.py#L1-L1" target="_blank" rel="noopener noreferrer">`alphagenome.data.ontology` (1:1)</a>
+
+
+
+
+
+### Transcript Annotations
+
+Handles the detailed annotation of transcripts, including exons, introns, and coding sequences, providing a structured representation of gene isoforms.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/transcript.py#L1-L1" target="_blank" rel="noopener noreferrer">`alphagenome.data.transcript` (1:1)</a>
+
+
+
+
+
+### Gene Annotations
+
+Manages comprehensive gene annotations, including gene names, symbols, and associated genomic coordinates, providing a high-level view of gene organization.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/gene_annotation.py#L1-L1" target="_blank" rel="noopener noreferrer">`alphagenome.data.gene_annotation` (1:1)</a>
+
+
+
+
+
+### Junction Data Structures
+
+Provides specialized data structures and utilities for handling and manipulating junction-specific information, often related to RNA splicing events.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/junction_data.py#L1-L1" target="_blank" rel="noopener noreferrer">`alphagenome.data.junction_data` (1:1)</a>
+
+
+
+
+
+### Interval Folding Utilities
+
+Offers utilities for manipulating and "folding" genomic intervals, which can be used for operations like creating symmetric views around a central point or preparing data for specific model inputs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/fold_intervals.py#L1-L1" target="_blank" rel="noopener noreferrer">`alphagenome.data.fold_intervals` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Interpretation_Analysis.md
+++ b/.codeboarding/Interpretation_Analysis.md
@@ -1,0 +1,97 @@
+```mermaid
+
+graph LR
+
+    In_silico_Mutagenesis_ISM_Core_Functions["In-silico Mutagenesis (ISM) Core Functions"]
+
+    Genomic_Data_Structures["Genomic Data Structures"]
+
+    Model_Output_Processing_DNA_Client_["Model Output Processing (DNA Client)"]
+
+    In_silico_Mutagenesis_ISM_Core_Functions -- "uses" --> Genomic_Data_Structures
+
+    In_silico_Mutagenesis_ISM_Core_Functions -- "consumes from" --> Model_Output_Processing_DNA_Client_
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Component Overview: Interpretation & Analysis (`alphagenome.interpretation.ism`)
+
+
+
+The `Interpretation & Analysis` component, specifically the `alphagenome.interpretation.ism` module, is dedicated to performing in-silico mutagenesis (ISM) analyses. It serves as a crucial bridge between raw model predictions and biological insights, by systematically generating and interpreting variant scores to understand the functional impact of genomic alterations.
+
+
+
+### In-silico Mutagenesis (ISM) Core Functions
+
+This component encapsulates the primary logic for generating single nucleotide variants and constructing in-silico mutagenesis matrices. It includes functions like `ism_variants` (for creating all possible single nucleotide variants within a genomic interval) and `ism_matrix` (for transforming variant effect scores into a structured matrix, highlighting the impact of mutations at each position).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `ism_variants`
+
+- `ism_matrix`
+
+
+
+
+
+### Genomic Data Structures
+
+This component provides the fundamental data structures necessary to represent genomic entities, such as `Interval` (defining a genomic region) and `Variant` (describing a genomic alteration). These structures are essential for precisely defining the scope of ISM analysis and representing the mutations being studied.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Interval`
+
+- `Variant`
+
+
+
+
+
+### Model Output Processing (DNA Client)
+
+This component, residing in the `models` layer, is responsible for interacting with the underlying deep learning models (e.g., via a DNA client) to obtain predictions and generate variant scores. The `ism_matrix` function explicitly consumes "variant effect scores" which are derived from the output of these models, indicating a direct dependency.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `score_variants`
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Model_Client_Output_Processing.md
+++ b/.codeboarding/Model_Client_Output_Processing.md
@@ -1,0 +1,115 @@
+```mermaid
+
+graph LR
+
+    DNA_Model_Client["DNA Model Client"]
+
+    DNA_Model_Output_Structures["DNA Model Output Structures"]
+
+    Variant_Scorers["Variant Scorers"]
+
+    Interval_Scorers["Interval Scorers"]
+
+    DNA_Model_Client -- "produces" --> DNA_Model_Output_Structures
+
+    DNA_Model_Client -- "orchestrates" --> Variant_Scorers
+
+    DNA_Model_Client -- "orchestrates" --> Interval_Scorers
+
+    Variant_Scorers -- "consumes" --> DNA_Model_Output_Structures
+
+    Interval_Scorers -- "consumes" --> DNA_Model_Output_Structures
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Model Client & Output Processing` subsystem is central to the AlphaGenome SDK, enabling interaction with remote DNA models and subsequent interpretation of their predictions.
+
+
+
+### DNA Model Client
+
+This component serves as the primary interface for interacting with remote AlphaGenome DNA models. It is responsible for constructing and executing gRPC requests, managing the communication lifecycle, and receiving raw model responses. It acts as the orchestrator for initiating model inference.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `DNA Model Client` (1:1)
+
+
+
+
+
+### DNA Model Output Structures
+
+This component defines the structured data types for encapsulating and organizing the raw predictions and scores received from the DNA models. It provides classes that represent the model's output in a standardized and accessible format for subsequent processing and analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `DNA Model Output Structures` (1:1)
+
+
+
+
+
+### Variant Scorers
+
+This component comprises a collection of specialized algorithms and classes designed to calculate and aggregate scores for genomic variants based on the processed model outputs. These scorers apply specific biological or statistical logic to quantify the impact or significance of individual variants.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Variant Scorers` (1:1)
+
+
+
+
+
+### Interval Scorers
+
+This component provides functionalities to calculate and aggregate scores for genomic intervals. It includes classes that process model predictions over defined genomic regions, offering an interval-level assessment of model outputs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Interval Scorers` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Protocol_Serialization.md
+++ b/.codeboarding/Protocol_Serialization.md
@@ -1,0 +1,83 @@
+```mermaid
+
+graph LR
+
+    alphagenome_protos["alphagenome.protos"]
+
+    alphagenome_tensor_utils["alphagenome.tensor_utils"]
+
+    alphagenome_protos -- "defines data structures for" --> alphagenome_data
+
+    alphagenome_models_dna_client -- "uses" --> alphagenome_protos
+
+    alphagenome_models_dna_output -- "uses" --> alphagenome_protos
+
+    alphagenome_tensor_utils -- "uses" --> alphagenome_protos
+
+    alphagenome_models_dna_client -- "uses" --> alphagenome_tensor_utils
+
+    alphagenome_data -- "uses" --> alphagenome_tensor_utils
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This component is fundamental to the `alphagenome` SDK, serving as the backbone for efficient and structured data exchange, particularly for gRPC-based communication with the backend. It ensures data consistency, integrity, and optimized transfer performance.
+
+
+
+### alphagenome.protos
+
+This sub-component encapsulates the auto-generated Python classes derived from Protocol Buffer (`.proto`) definitions. These definitions serve as the canonical data schemas for all inter-process communication within the SDK and with external services (e.g., the gRPC backend). They define the structure of genomic entities, model inputs, model outputs, and service contracts, ensuring type safety and efficient serialization/deserialization.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `alphagenome.protos.dna_model_pb2` (1:1)
+
+- `alphagenome.protos.dna_model_service_pb2` (1:1)
+
+- `alphagenome.protos.tensor_pb2` (1:1)
+
+- `alphagenome.protos.tensor_pb2_grpc` (1:1)
+
+
+
+
+
+### alphagenome.tensor_utils
+
+This sub-component provides a suite of utility functions specifically designed for the efficient handling of tensor data. Its primary responsibilities include converting NumPy arrays to and from the Protocol Buffer `TensorProto` format, and implementing compression/decompression mechanisms (e.g., using `zstandard`) to minimize data transfer size and latency for large tensor payloads.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/tensor_utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`alphagenome.tensor_utils` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Visualization.md
+++ b/.codeboarding/Visualization.md
@@ -1,0 +1,245 @@
+```mermaid
+
+graph LR
+
+    AbstractComponent["AbstractComponent"]
+
+    Plot_Orchestrator["Plot Orchestrator"]
+
+    TrackPlotter["TrackPlotter"]
+
+    SashimiPlotter["SashimiPlotter"]
+
+    TranscriptAnnotator["TranscriptAnnotator"]
+
+    SeqLogoPlotter["SeqLogoPlotter"]
+
+    ContactMapPlotter["ContactMapPlotter"]
+
+    AbstractAnnotationComponent["AbstractAnnotationComponent"]
+
+    TranscriptRenderer["TranscriptRenderer"]
+
+    EmptyComponent["EmptyComponent"]
+
+    Plot_Orchestrator -- "orchestrates" --> AbstractComponent
+
+    Plot_Orchestrator -- "uses" --> EmptyComponent
+
+    TrackPlotter -- "inherits from" --> AbstractComponent
+
+    SashimiPlotter -- "inherits from" --> AbstractComponent
+
+    TranscriptAnnotator -- "inherits from" --> AbstractComponent
+
+    SeqLogoPlotter -- "inherits from" --> AbstractComponent
+
+    ContactMapPlotter -- "inherits from" --> AbstractComponent
+
+    AbstractAnnotationComponent -- "inherits from" --> AbstractComponent
+
+    Plot_Orchestrator -- "uses" --> AbstractAnnotationComponent
+
+    TranscriptAnnotator -- "delegates to" --> TranscriptRenderer
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Visualization` component in `alphagenome` provides a robust and extensible framework for generating diverse genomic data visualizations. It adheres to a modular design, leveraging abstract base classes and concrete implementations to offer both low-level plotting primitives and high-level, reusable components for complex genomic plots.
+
+
+
+### AbstractComponent
+
+This is the foundational abstract base class for all visual components within the `alphagenome.visualization` module. It defines the common interface and properties that all concrete plotting components must implement, ensuring consistency and extensibility. It's crucial for enabling polymorphism and a plug-and-play architecture for different plot types.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `AbstractComponent`
+
+
+
+
+
+### Plot Orchestrator
+
+This is the primary entry point for users to construct complex visualizations. It orchestrates the rendering of multiple `AbstractComponent` instances onto a single `matplotlib` figure, managing layout, titles, and annotations. It acts as the high-level API for combining various genomic plot elements.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/visualization/plot.py" target="_blank" rel="noopener noreferrer">`plot`</a>
+
+
+
+
+
+### TrackPlotter
+
+A concrete implementation of `AbstractComponent` designed for visualizing generic genomic tracks. This includes data like read coverage, signal data, or any quantitative data across a genomic interval. It provides the functionality to render these tracks within the orchestrated plot.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Tracks`
+
+
+
+
+
+### SashimiPlotter
+
+A specialized concrete implementation of `AbstractComponent` for visualizing splicing events. It displays read coverage and junction counts, which are critical for analyzing gene expression and alternative splicing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `Sashimi`
+
+
+
+
+
+### TranscriptAnnotator
+
+A concrete implementation of `AbstractComponent` dedicated to annotating and visualizing gene transcripts, including the detailed structure of exons and introns. It provides a visual representation of gene models within the genomic context.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `TranscriptAnnotation`
+
+
+
+
+
+### SeqLogoPlotter
+
+A concrete implementation of `AbstractComponent` for generating sequence logo plots. These plots are used to represent sequence conservation and identify consensus sequences, particularly useful in analyzing binding sites or motifs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `SeqLogo`
+
+
+
+
+
+### ContactMapPlotter
+
+A concrete implementation of `AbstractComponent` for visualizing genomic contact maps, typically used in Hi-C data analysis to show the spatial proximity of genomic regions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `ContactMaps`
+
+
+
+
+
+### AbstractAnnotationComponent
+
+An abstract base class that extends `AbstractComponent`, specifically designed for various types of annotations that can be overlaid on genomic plots. This allows for a structured way to add features like interval highlights or variant markers.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `AbstractAnnotation`
+
+
+
+
+
+### TranscriptRenderer
+
+A lower-level utility function responsible for the detailed drawing of individual transcripts, including their exons and introns. While not a `plot_component` itself, it serves as a crucial helper for the `TranscriptAnnotator` component, handling the intricate rendering logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/visualization/plot_transcripts.py#L90-L163" target="_blank" rel="noopener noreferrer">`plot_transcripts` (90:163)</a>
+
+
+
+
+
+### EmptyComponent
+
+A specialized concrete implementation of `AbstractComponent` used internally by the `Plot Orchestrator`. Its primary purpose is to create an empty axis at the top of the plot, specifically for placing labels from annotation components, ensuring proper layout and avoiding overlaps.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `EmptyComponent`
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,187 @@
+```mermaid
+
+graph LR
+
+    Genomic_Data_Management["Genomic Data Management"]
+
+    Protocol_Serialization["Protocol & Serialization"]
+
+    Model_Client_Output_Processing["Model Client & Output Processing"]
+
+    Interpretation_Analysis["Interpretation & Analysis"]
+
+    Visualization["Visualization"]
+
+    Genomic_Data_Management -- "provides data to" --> Model_Client_Output_Processing
+
+    Genomic_Data_Management -- "provides data to" --> Interpretation_Analysis
+
+    Genomic_Data_Management -- "provides data to" --> Visualization
+
+    Genomic_Data_Management -- "uses" --> Protocol_Serialization
+
+    Protocol_Serialization -- "facilitates communication for" --> Model_Client_Output_Processing
+
+    Protocol_Serialization -- "supports data handling for" --> Genomic_Data_Management
+
+    Model_Client_Output_Processing -- "processes input from" --> Genomic_Data_Management
+
+    Model_Client_Output_Processing -- "communicates via" --> Protocol_Serialization
+
+    Model_Client_Output_Processing -- "generates data for" --> Interpretation_Analysis
+
+    Model_Client_Output_Processing -- "provides results to" --> Visualization
+
+    Interpretation_Analysis -- "analyzes output from" --> Model_Client_Output_Processing
+
+    Interpretation_Analysis -- "leverages" --> Genomic_Data_Management
+
+    Visualization -- "renders data from" --> Genomic_Data_Management
+
+    Visualization -- "plots results from" --> Model_Client_Output_Processing
+
+    click Genomic_Data_Management href "https://github.com/google-deepmind/alphagenome/blob/main/.codeboarding//Genomic_Data_Management.md" "Details"
+
+    click Protocol_Serialization href "https://github.com/google-deepmind/alphagenome/blob/main/.codeboarding//Protocol_Serialization.md" "Details"
+
+    click Model_Client_Output_Processing href "https://github.com/google-deepmind/alphagenome/blob/main/.codeboarding//Model_Client_Output_Processing.md" "Details"
+
+    click Interpretation_Analysis href "https://github.com/google-deepmind/alphagenome/blob/main/.codeboarding//Interpretation_Analysis.md" "Details"
+
+    click Visualization href "https://github.com/google-deepmind/alphagenome/blob/main/.codeboarding//Visualization.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `alphagenome` project, designed as a Python SDK for bioinformatics and deep learning in genomics, exhibits a clear modular and layered architecture. The analysis consolidates the identified components into five core logical units, ensuring a high-level data flow overview that aligns with typical SDK patterns.
+
+
+
+### Genomic Data Management [[Expand]](./Genomic_Data_Management.md)
+
+This foundational component defines and manages all core genomic entities, including intervals, variants, junctions, and quantitative genomic track data. It also handles biological ontology terms, gene, and transcript annotations. It provides utilities for data manipulation, serialization/deserialization, and preparing data for subsequent processing or visualization.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/genome.py" target="_blank" rel="noopener noreferrer">`alphagenome.data.genome`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/track_data.py" target="_blank" rel="noopener noreferrer">`alphagenome.data.track_data`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/junction_data.py" target="_blank" rel="noopener noreferrer">`alphagenome.data.junction_data`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/ontology.py" target="_blank" rel="noopener noreferrer">`alphagenome.data.ontology`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/transcript.py" target="_blank" rel="noopener noreferrer">`alphagenome.data.transcript`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/gene_annotation.py" target="_blank" rel="noopener noreferrer">`alphagenome.data.gene_annotation`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/data/fold_intervals.py" target="_blank" rel="noopener noreferrer">`alphagenome.data.fold_intervals`</a>
+
+
+
+
+
+### Protocol & Serialization [[Expand]](./Protocol_Serialization.md)
+
+This component is responsible for defining the structured data formats (using Protocol Buffers) for efficient inter-process communication, primarily for gRPC interactions with the backend. It also includes utilities for packing, unpacking, compressing, and decompressing tensor data, optimizing data transfer efficiency.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `alphagenome.protos`
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/tensor_utils.py" target="_blank" rel="noopener noreferrer">`alphagenome.tensor_utils`</a>
+
+
+
+
+
+### Model Client & Output Processing [[Expand]](./Model_Client_Output_Processing.md)
+
+This is the primary client-side interface for interacting with remote AlphaGenome DNA models. It handles the construction and execution of gRPC requests, receiving responses, and then structuring and processing the model predictions and scores. This includes functionalities for scoring genomic variants and intervals based on model outputs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/models/dna_client.py" target="_blank" rel="noopener noreferrer">`alphagenome.models.dna_client`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/models/dna_output.py" target="_blank" rel="noopener noreferrer">`alphagenome.models.dna_output`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/models/variant_scorers.py" target="_blank" rel="noopener noreferrer">`alphagenome.models.variant_scorers`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/models/interval_scorers.py" target="_blank" rel="noopener noreferrer">`alphagenome.models.interval_scorers`</a>
+
+
+
+
+
+### Interpretation & Analysis [[Expand]](./Interpretation_Analysis.md)
+
+This component implements advanced computational biology analyses, with a specific focus on in-silico mutagenesis (ISM). It consumes processed model outputs to systematically generate and interpret variant scores, providing crucial insights into the functional impact of genomic alterations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/interpretation/ism.py" target="_blank" rel="noopener noreferrer">`alphagenome.interpretation.ism`</a>
+
+
+
+
+
+### Visualization [[Expand]](./Visualization.md)
+
+This component offers a comprehensive suite of tools for visualizing genomic data and model predictions. It includes both low-level plotting primitives and high-level, reusable components for constructing complex genomic plots, such as track views, sashimi plots, and detailed transcript annotations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/visualization/plot.py" target="_blank" rel="noopener noreferrer">`alphagenome.visualization.plot`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/visualization/plot_components.py" target="_blank" rel="noopener noreferrer">`alphagenome.visualization.plot_components`</a>
+
+- <a href="https://github.com/google-deepmind/alphagenome/blob/main/src/alphagenome/visualization/plot_transcripts.py#L90-L163" target="_blank" rel="noopener noreferrer">`alphagenome.visualization.plot_transcripts` (90:163)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
In this PR I am introducing a diagram representation for the alphagenome's codebase. You can see how the docs render here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/alphagenome/on_boarding.md

The idea of these documents is to help people get up-to-speed with the alphagenome codeabse. They provide a high-level overview of the main components and how they interact with each other, so that scientists and coders from all background can get the main idea of the codebase and focus on the part which is interesting to them. Would love to hear what is your take on diagram first documentation in general!

Any feedback is more than welcome! If you like what you see I can also integrate our free github action to your repo, so the diagrams are always up-to-date!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.