### PR TITLE
feat: add REF/ALT alignment utility for visualization (Issue #23)

### DIFF
--- a/docs/source/visualization_library_basics.md
+++ b/docs/source/visualization_library_basics.md
@@ -41,6 +41,27 @@ components -- such as locations of promoters or variants -- can be overlaid via
 a list of annotations that are passed to
 {func}`~alphagenome.visualization.plot_components.plot`.
 
+## Aligning REF and ALT tracks
+
+When visualizing long variants (such as large deletions or insertions), the REF and ALT tracks may have different lengths and coordinate systems. To correctly overlay them using {class}`~alphagenome.visualization.plot_components.OverlaidTracks`, you should first align them to a common coordinate system (usually REF).
+
+We provide a utility function for this purpose:
+
+```python
+from alphagenome.visualization import track_alignment
+
+# ... generate ref_track, alt_track, and variant ...
+
+ref_aligned, alt_aligned = track_alignment.align_ref_alt_tracks(
+    ref_track, alt_track, variant
+)
+
+# Now plot using OverlaidTracks
+# ...
+```
+
+This utility interpolates the ALT track onto the REF coordinate grid. Deleted regions are filled with NaNs (appearing as gaps), and insertions are compressed. This ensures that the tracks are visually aligned.
+
 ## Custom plotting
 
 For users interested in configuring novel components, extend the

--- a/src/alphagenome/visualization/track_alignment.py
+++ b/src/alphagenome/visualization/track_alignment.py
@@ -1,0 +1,146 @@
+"""Utilities for aligning track data for visualization."""
+
+import copy
+from typing import Tuple
+
+from alphagenome.data import genome
+from alphagenome.data import track_data
+import numpy as np
+import scipy.interpolate
+
+
+def align_ref_alt_tracks(
+    ref_track: track_data.TrackData,
+    alt_track: track_data.TrackData,
+    variant: genome.Variant,
+) -> Tuple[track_data.TrackData, track_data.TrackData]:
+  """Aligns REF and ALT TrackData to a common REF-based coordinate grid.
+
+  This is intended for visualization only. It keeps the REF track unchanged
+  (except possibly for minor type conversions), and re-maps the ALT values
+  onto the REF coordinate grid using interpolation.
+
+  - For deletions: the REF interval contains coordinates that are missing in
+    ALT. These are represented in the aligned ALT track as NaNs.
+  - For insertions: ALT has additional coordinates locally, which get
+    compressed when remapped to the REF grid via interpolation.
+
+  The returned TrackData objects share:
+    - The same interval (REF interval).
+    - The same resolution.
+    - The same shape for `values`.
+
+  Args:
+    ref_track: TrackData from the reference model output.
+    alt_track: TrackData from the alternate model output.
+    variant: The variant used to generate predictions.
+
+  Returns:
+    A tuple (ref_aligned, alt_aligned) both on the REF coordinate system.
+  """
+  # We use ref_track as the target coordinate system
+  target_interval = ref_track.interval
+  resolution = ref_track.resolution
+
+  # Construct REF x-coordinates (target grid)
+  # Corresponds to: interval.start + i * resolution
+  ref_x = (
+      np.arange(ref_track.values.shape[0]) * resolution + target_interval.start
+  )
+  ref_x_centers = ref_x + resolution / 2.0
+
+  # Construct ALT x-coordinates (source grid) in its own "ALT" space
+  assert alt_track.interval is not None
+  alt_start = alt_track.interval.start
+  alt_x_centers_native = (
+      np.arange(alt_track.values.shape[0]) * alt_track.resolution
+      + alt_start
+      + alt_track.resolution / 2.0
+  )
+
+  # Now map ALT native coords to REF coords.
+  # Logic:
+  # Upstream of variant: x_ref = x_alt
+  # Downstream of variant: x_ref = x_alt - len_alt + len_ref
+  # Inside variant: Linear mapping
+
+  var_start = variant.start
+  len_ref = len(variant.reference_bases)
+  len_alt = len(variant.alternate_bases)
+
+  alt_x_centers_mapped = np.copy(alt_x_centers_native)
+
+  # Mask for upstream, downstream
+  mask_upstream = alt_x_centers_native < var_start
+  mask_downstream = alt_x_centers_native >= (var_start + len_alt)
+  mask_inside = (~mask_upstream) & (~mask_downstream)
+
+  # Apply shifts
+  # Upstream: No change.
+
+  # Downstream: Add (len_ref - len_alt)
+  shift = len_ref - len_alt
+  alt_x_centers_mapped[mask_downstream] += shift
+
+  # Inside: Stretch/Compress
+  # We want to map [var_start, var_start + len_alt) to
+  # [var_start, var_start + len_ref)
+  if np.any(mask_inside) and len_alt > 0:
+    if len_ref < len_alt:
+      scale = len_ref / len_alt
+    else:
+      scale = 1.0
+    alt_x_centers_mapped[mask_inside] = (
+        var_start + (alt_x_centers_native[mask_inside] - var_start) * scale
+    )
+
+  # Make a copy of REF track for aligned output (to preserve metadata)
+  ref_aligned = ref_track # It's already in REF coords.
+
+  # Interpolate ALT values onto REF grid
+  # values shape: (positional_bins, num_tracks)
+  # We loop over tracks or use interp1d with axis.
+
+  alt_values = alt_track.values
+  # Cast to float if not already, because interpolation requires it.
+  is_integer = np.issubdtype(alt_values.dtype, np.integer) or np.issubdtype(
+      alt_values.dtype, np.bool_
+  )
+
+  if is_integer:
+    # Nearest neighbor interpolation
+    alt_values = alt_values.astype(np.float32)
+    interp_kind = 'nearest'
+  else:
+    interp_kind = 'linear'
+
+  interp_func = scipy.interpolate.interp1d(
+      alt_x_centers_mapped,
+      alt_values,
+      kind=interp_kind,
+      axis=0,
+      bounds_error=False,
+      fill_value=np.nan,
+      assume_sorted=True,
+  )
+
+  new_alt_values = interp_func(ref_x_centers)
+
+  # For Deletions: Explicitly NaN out the deleted region in REF coordinates.
+  # The deleted region is [var_start + len_alt, var_start + len_ref).
+  if len_ref > len_alt:  # Deletion
+    gap_start = var_start + len_alt
+    gap_end = var_start + len_ref
+    mask_gap = (ref_x_centers >= gap_start) & (ref_x_centers < gap_end)
+    new_alt_values[mask_gap] = np.nan
+
+  # Create new TrackData for ALT
+  alt_aligned = track_data.TrackData(
+      values=new_alt_values,
+      resolution=resolution,
+      metadata=alt_track.metadata.copy(),
+      interval=target_interval,  # Now matches REF
+      uns=copy.deepcopy(alt_track.uns),
+  )
+
+  return ref_aligned, alt_aligned

--- a/src/alphagenome/visualization/track_alignment_test.py
+++ b/src/alphagenome/visualization/track_alignment_test.py
@@ -1,0 +1,181 @@
+"""Tests for track_alignment."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from alphagenome.data import genome
+from alphagenome.data import track_data
+from alphagenome.visualization import track_alignment
+import numpy as np
+import pandas as pd
+
+
+class TrackAlignmentTest(parameterized.TestCase):
+
+  def test_align_tracks_deletion_1bp(self):
+    # Setup simple REF track
+    resolution = 1
+    ref_start = 100
+    ref_len = 10
+    ref_vals = np.arange(ref_len, dtype=np.float32).reshape(
+        ref_len, 1
+    )  # [0, 1, 2, ..., 9]
+    ref_metadata = pd.DataFrame({'name': ['t1'], 'strand': ['.']})
+    ref_interval = genome.Interval('chr1', ref_start, ref_start + ref_len)
+    ref_track = track_data.TrackData(
+        ref_vals, ref_metadata, resolution=resolution, interval=ref_interval
+    )
+
+    # Variant: Deletion at 103 (0-based index of first ref base).
+    # ref="ABC" (length 3), alt="A" (length 1).
+    # Variant start = 103.
+    # Gap should correspond to REF bases at 103+1=104 and 103+2=105.
+
+    # Construct ALT track.
+    # Sequence: 100..102 (3) | 103 (1) | 106..109 (4)
+    # Total length: 3 + 1 + 4 = 8.
+    alt_vals = np.array(
+        [
+            0,
+            1,
+            2,  # 100, 101, 102
+            3,  # 103 (matches REF 103)
+            6,
+            7,
+            8,
+            9,  # 106, 107, 108, 109
+        ],
+        dtype=np.float32,
+    ).reshape(8, 1)
+
+    alt_len = len(alt_vals)
+    alt_interval = genome.Interval(
+        'chr1', ref_start, ref_start + alt_len
+    )
+    alt_track = track_data.TrackData(
+        alt_vals, ref_metadata, resolution=resolution, interval=alt_interval
+    )
+
+    variant = genome.Variant(
+        chromosome='chr1',
+        position=104,  # 1-based. 104 -> index 103 0-based.
+        reference_bases='ATG',  # len 3
+        alternate_bases='A',  # len 1
+    )
+
+    ref_aligned, alt_aligned = track_alignment.align_ref_alt_tracks(
+        ref_track, alt_track, variant
+    )
+
+    self.assertEqual(ref_aligned.interval, alt_aligned.interval)
+    self.assertEqual(ref_aligned.values.shape, alt_aligned.values.shape)
+
+    # Check values
+    # 0, 1, 2 should match
+    np.testing.assert_array_almost_equal(
+        alt_aligned.values[:3], [[0], [1], [2]]
+    )
+    # 3 should match
+    np.testing.assert_array_almost_equal(alt_aligned.values[3:4], [[3]])
+
+    # Gap: indices 4 and 5 (positions 104, 105).
+    self.assertTrue(np.isnan(alt_aligned.values[4]))
+    self.assertTrue(np.isnan(alt_aligned.values[5]))
+
+    # After gap: 6, 7, 8, 9. Index 6, 7, 8, 9.
+    np.testing.assert_array_almost_equal(
+        alt_aligned.values[6:], [[6], [7], [8], [9]]
+    )
+
+  def test_align_tracks_insertion_1bp(self):
+    resolution = 1
+    ref_start = 100
+    ref_len = 10
+    ref_vals = np.arange(ref_len, dtype=np.float32).reshape(ref_len, 1)
+    ref_metadata = pd.DataFrame({'name': ['t1'], 'strand': ['.']})
+    ref_interval = genome.Interval('chr1', ref_start, ref_start + ref_len)
+    ref_track = track_data.TrackData(
+        ref_vals, ref_metadata, resolution=resolution, interval=ref_interval
+    )
+
+    # Insertion: ref=A, alt=ATG. len=1, len=3.
+    # at 103.
+    # ALT vals:
+    # 0, 1, 2
+    # 3.0, 3.3, 3.6 (inserted/expanded region)
+    # 4, 5, 6, 7, 8, 9
+    alt_vals = np.array(
+        [0, 1, 2, 3, 3.3, 3.6, 4, 5, 6, 7, 8, 9], dtype=np.float32
+    ).reshape(12, 1)
+
+    alt_interval = genome.Interval('chr1', ref_start, ref_start + 12)
+    alt_track = track_data.TrackData(
+        alt_vals, ref_metadata, resolution=resolution, interval=alt_interval
+    )
+
+    variant = genome.Variant(
+        chromosome='chr1',
+        position=104,  # 1-based. index 103.
+        reference_bases='A',
+        alternate_bases='ATG',
+    )
+
+    ref_aligned, alt_aligned = track_alignment.align_ref_alt_tracks(
+        ref_track, alt_track, variant
+    )
+
+    self.assertEqual(
+        ref_aligned.values.shape, alt_aligned.values.shape
+    )  # Should be 10 back.
+
+    # 0..2 match
+    np.testing.assert_array_almost_equal(
+        alt_aligned.values[:3], [[0], [1], [2]]
+    )
+
+    # At 3 (103): We expect compression.
+    # Points 3, 3.3, 3.6 map to [3, 4) in REF.
+    # REF index 3 corresponds to native 3.
+    # REF index 4 corresponds to native 4 (value 4).
+    # The intermediate values might be skipped or interpolated depending on grid.
+    np.testing.assert_array_almost_equal(alt_aligned.values[3], [3.3])
+    np.testing.assert_array_almost_equal(alt_aligned.values[4], [4])
+
+  def test_align_tracks_deletion_coarse_resolution(self):
+    # Resolution 10.
+    # Ref len 100. 10 bins.
+    res = 10
+    ref_interval = genome.Interval('chr1', 1000, 1100)
+    ref_vals = np.zeros((10, 1), dtype=np.float32)
+    ref_metadata = pd.DataFrame({'name': ['t1'], 'strand': ['.']})
+    ref_track = track_data.TrackData(
+        ref_vals, ref_metadata, resolution=res, interval=ref_interval
+    )
+
+    # Deletion of 20bp at 1040. (2 bins).
+    # REF: 1040-1060 deleted.
+    # Variant: pos 1041 (1-based), so index 1040.
+    variant = genome.Variant(
+        'chr1', 1041, 'A' * 21, 'A'
+    )  # 21 bases -> 1 base. Delta 20.
+
+    # ALT track: length 80. (8 bins).
+    alt_vals = np.ones((8, 1), dtype=np.float32)
+    alt_interval = genome.Interval('chr1', 1000, 1080)
+    alt_track = track_data.TrackData(
+        alt_vals, ref_metadata, resolution=res, interval=alt_interval
+    )
+
+    ref_aligned, alt_aligned = track_alignment.align_ref_alt_tracks(
+        ref_track, alt_track, variant
+    )
+
+    # Bins 1040, 1050 are in the deleted region [1041, 1061).
+    # Centers 1045, 1055 fall inside.
+    self.assertTrue(np.isnan(alt_aligned.values[4]))
+    self.assertTrue(np.isnan(alt_aligned.values[5]))
+    self.assertEqual(alt_aligned.values[0, 0], 1.0)
+    self.assertEqual(alt_aligned.values[7, 0], 1.0)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
This adds a new utility function align_ref_alt_tracks to alphagenome.visualization. It handles the coordinate misalignment that occurs when plotting long indels by mapping ALT tracks to the REF coordinate system. Deletions are represented as NaNs and insertions are compressed, ensuring visual alignment in OverlaidTracks.