### PR TITLE
fix TrackData slicing

### DIFF
--- a/src/alphagenome/data/track_data.py
+++ b/src/alphagenome/data/track_data.py
@@ -242,9 +242,9 @@ class TrackData:
           'equal to width.'
       )
 
-    if (end - start) % self.resolution != 0:
+    if start % self.resolution != 0 or end % self.resolution != 0:
       raise ValueError(
-          f'end - start needs to be to be divisible by {self.resolution=}'
+          f'start and end need to be divisible by {self.resolution=}'
       )
 
     sl = slice(self.bin_index(start), self.bin_index(end))
@@ -593,7 +593,10 @@ class TrackData:
           raise IndexError('Slice step must be 1 for positional indexing.')
         if position_index != slice(None):
           tdata = tdata.slice_by_positions(
-              position_index.start, position_index.stop
+              0 if position_index.start is None else position_index.start,
+              tdata.width
+              if position_index.stop is None
+              else position_index.stop,
           )
       case genome.Interval():
         tdata = tdata.slice_by_interval(position_index)

--- a/src/alphagenome/data/track_data_test.py
+++ b/src/alphagenome/data/track_data_test.py
@@ -156,11 +156,11 @@ class TrackDataSlicingTest(parameterized.TestCase):
       self.assertEqual(tdata2.interval.end, 2)
       self.assertEqual(tdata2.width, tdata2.interval.width)
       self.assertEqual(tdata2.width, 2)
-      # Fails because (end - start) is not evenly divisible by resolution.
+      # Fails because slice endpoints do not align with the reference bins.
       with self.assertRaises(ValueError):
         tdata.slice_by_positions(0, 3)
       with self.assertRaises(ValueError):
-        tdata.slice_by_positions(0, 1)
+        tdata.slice_by_positions(1, 3)
     # Fails because there are no positional axes to slice into.
     else:
       self.assertEqual(tdata.width, 0)
@@ -204,15 +204,15 @@ class TrackDataSlicingTest(parameterized.TestCase):
       self.assertEqual(tdata2.interval.end, 3)
       self.assertEqual(tdata2.width, tdata2.interval.width)
       self.assertEqual(tdata2.width, 2)
-      # Fails because (end - start) is not evenly divisible by resolution.
+      # Fails because slice endpoints do not align with the reference bins.
       with self.assertRaises(ValueError):
         tdata.slice_by_interval(genome.Interval('chr1', 1, 4))
       with self.assertRaises(ValueError):
-        tdata.slice_by_interval(genome.Interval('chr1', 1, 2))
+        tdata.slice_by_interval(genome.Interval('chr1', 2, 4))
 
       # Same would work if we set match_resolution=True.
       tdata2 = tdata.slice_by_interval(
-          genome.Interval('chr1', 1, 4), match_resolution=True
+          genome.Interval('chr1', 2, 4), match_resolution=True
       )
       self.assertIsNotNone(tdata2.interval)
       self.assertEqual(tdata2.interval.start, 1)
@@ -695,19 +695,30 @@ class TrackDataGetItemTest(parameterized.TestCase):
         values, metadata, resolution=1, interval=interval
     )
 
-  @parameterized.parameters([
-      dict(num_positional=1),
-      dict(num_positional=2),
-  ])
-  def test_getitem_positional_slice(self, num_positional: int):
+  @parameterized.product(
+      num_positional=[1, 2],
+      slice_case=[
+          (slice(1, 3), 1, 3),
+          (slice(None, 3), 0, 3),
+          (slice(1, None), 1, 4),
+          (slice(None, 0), 0, 0),
+          (slice(4, None), 4, 4),
+          (slice(None), 0, 4),
+      ],
+  )
+  def test_getitem_positional_slice(self, num_positional: int, slice_case):
     tdata = self._get_test_data(num_positional)
-    sliced_tdata = tdata[1:3]
-    self.assertEqual(sliced_tdata.width, 2)
-    expected_shape = tuple([2] * num_positional + [5])
+    position_slice, start, end = slice_case
+    sliced_tdata = tdata[position_slice]
+    self.assertEqual(sliced_tdata.width, end - start)
+    expected_shape = tuple([end - start] * num_positional + [5])
     assert sliced_tdata.interval is not None
     self.assertEqual(sliced_tdata.values.shape, expected_shape)
-    self.assertEqual(sliced_tdata.interval.start, 11)
-    self.assertEqual(sliced_tdata.interval.end, 13)
+    self.assertEqual(sliced_tdata.interval.start, 10 + start)
+    self.assertEqual(sliced_tdata.interval.end, 10 + end)
+    np.testing.assert_array_equal(
+        sliced_tdata.values, tdata.values[(position_slice,) * num_positional]
+    )
 
     with self.assertRaises(IndexError):
       _ = tdata[1:3:2]


### PR DESCRIPTION
This relates to #48 

`TrackData` slicing can cause mislabelled genomic coordinates if endpoints aren't aligned with the reference bin boundaries. For instance, with `x` covering `[0,384)` at 128bp resolution and values `[10,20,30]`:

| Expression           | values    | Actual coordinates | Assigned coordinates | Error (bp) |
| -------------------- | --------- | ------------------ | -------------------- | ---------- |
| `x[127:383]`         | `[10,20]` | `[0,256)`          | `[127,383)`          | 127        |
| `x[127:383][127:255]` | `[10]`    | `[0,128)`          | `[254,382)`          | 254        |

So downstream code relying on the assigned coordinates can be affected. Also, for repeated calls, errors seem to stack additively. Take x covering [0,768) at 128 bp resolution,

```python
firstCall = x[127:767]
secondCall = firstCall[127:639]
thirdCall = secondCall[127:511]
fourthCall = thirdCall[127:383]
fifthCall = fourthCall[127:255]
```

| Object       | Actual coordinates | Assigned coordinates | Error  |
| ------------ | ------------------ | -------------------- | ------ |
| `firstCall`  | `[0,640)`          | `[127,767)`          | 127 bp |
| `secondCall` | `[0,512)`          | `[254,766)`          | 254 bp |
| `thirdCall`  | `[0,384)`          | `[381,765)`          | 381 bp |
| `fourthCall` | `[0,256)`          | `[508,764)`          | 508 bp |
| `fifthCall`  | `[0,128)`          | `[635,763)`          | 635 bp |


This PR opts to raise `ValueError` for misaligned endpoints, but preserves explicit handling through `match_resolution=True` in `slice_by_interval` to round endpoints to the reference bin boundaries. This arg is used pretty consistently throughout documentation, anyways.

Raising `ValueError` is discretionary on my end and could break existing code that uses misaligned slice endpoints without the explicit matched resolution. Maybe there is a more graceful alternative.

*Note, for easier merging, the missing-endpoint handling issue previously covered in this PR is now addressed separately in PR #49.*